### PR TITLE
[JobOfferts]: Add job offerts list with mock data and styling improvements

### DIFF
--- a/src/common/components/ButtonLink/ButtonLink.tsx
+++ b/src/common/components/ButtonLink/ButtonLink.tsx
@@ -11,12 +11,10 @@ const ButtonLink = ({ to, children, className = "" }: ButtonLinkProps) => {
   return (
     <Link
       to={to}
-      className={`inline-flex items-center gap-2
+      className={`inline-flex items-center 
     px-4 py-2
     text-primary
     text-sm font-medium
-    rounded-md
-    border border-transparent
     transition-colors
     hover:bg-primary-hover/10 
     hover:text-primary-hover

--- a/src/common/components/Table/Table.tsx
+++ b/src/common/components/Table/Table.tsx
@@ -3,11 +3,7 @@ interface TableProps {
 }
 
 const Table = ({ children }: TableProps) => {
-  return (
-    <article className="flex flex-col gap-3 my-5 border-b-2 pb-2 border-primary">
-      {children}
-    </article>
-  );
+  return <article className="flex flex-col my-5">{children}</article>;
 };
 
 export default Table;

--- a/src/components/DashboardPage/EditedOfferts/EditedOfferts.tsx
+++ b/src/components/DashboardPage/EditedOfferts/EditedOfferts.tsx
@@ -21,16 +21,18 @@ const EditedOfferts = () => {
     <Card className="p-5 min-w-[350px]">
       <h2 className="text-3xl font-bold">Ostatnio edytowane oferty</h2>
       <Table>
-        <div className="flex flex-wrap justify-between text-text-muted border-b-2 pb-2 border-primary">
-          <p className="flex-1">Nazwa</p>
-          <p className="flex-1">Stasus</p>
-          <p className="flex-1">Kandydaci</p>
+        <div className="flex flex-wrap text-text-muted border-b-2 pb-2 border-primary">
+          <p className="flex-1 text-center">Nazwa</p>
+          <p className="flex-1 text-center">Stasus</p>
+          <p className="flex-1 text-center">Kandydaci</p>
         </div>
         {editedOfferts.map((offert) => (
           <SingleEditedOffert key={offert.id} offert={offert} />
         ))}
       </Table>
-      <ButtonLink to={Paths.OFFERS}>Pokaż wszystkie oferty</ButtonLink>
+      <ButtonLink className="rounded-md" to={Paths.OFFERS}>
+        Pokaż wszystkie oferty
+      </ButtonLink>
     </Card>
   );
 };

--- a/src/components/DashboardPage/EditedOfferts/SingleEditedOffert/SingleEditedOffert.tsx
+++ b/src/components/DashboardPage/EditedOfferts/SingleEditedOffert/SingleEditedOffert.tsx
@@ -7,10 +7,10 @@ interface SingleEditedOffertProps {
 
 const SingleEditedOffert = ({ offert }: SingleEditedOffertProps) => {
   return (
-    <ButtonLink to="/">
-      <p className="flex-1 mr-5">{offert.ofertTitle}</p>
-      <p className="flex-1 mr-10">{offert.ofertStatus}</p>
-      <p className="flex-1">{offert.candidates}</p>
+    <ButtonLink to="/" className="border-b-2 border-primary py-4">
+      <p className="flex-1 text-center">{offert.ofertTitle}</p>
+      <p className="flex-1 text-center">{offert.ofertStatus}</p>
+      <p className="flex-1 text-center">{offert.candidates}</p>
     </ButtonLink>
   );
 };

--- a/src/components/DashboardPage/LatestCandidates/LatestCandidates.tsx
+++ b/src/components/DashboardPage/LatestCandidates/LatestCandidates.tsx
@@ -21,15 +21,17 @@ const LatestCandidates = () => {
       <h2 className="text-3xl font-bold">Najnowsi Kandydaci</h2>
       <Table>
         <div className="flex flex-wrap justify-between text-text-muted border-b-2 pb-2 border-primary">
-          <p className="flex-1">Imię i nazwisko</p>
-          <p className="flex-1">Aplikował</p>
-          <p className="flex-1">CV</p>
+          <p className="flex-1 text-center">Imię i nazwisko</p>
+          <p className="flex-1 text-center">Aplikował</p>
+          <p className="flex-1 text-center">CV</p>
         </div>
         {latestCandidates.map((candidate) => (
           <SingleCandidate key={candidate.id} candidate={candidate} />
         ))}
       </Table>
-      <ButtonLink to={Paths.CANDIDATES}>Pokaż wszystkich kandydatów</ButtonLink>
+      <ButtonLink className="rounded-md" to={Paths.CANDIDATES}>
+        Pokaż wszystkich kandydatów
+      </ButtonLink>
     </Card>
   );
 };

--- a/src/components/DashboardPage/LatestCandidates/SingleCandidate/SingleCandidate.tsx
+++ b/src/components/DashboardPage/LatestCandidates/SingleCandidate/SingleCandidate.tsx
@@ -7,10 +7,10 @@ interface SingleCandidateProps {
 
 const SingleCandidate = ({ candidate }: SingleCandidateProps) => {
   return (
-    <ButtonLink to="/" className="flex flex-wrap justify-between">
-      <p className="flex-1">{candidate.fullname}</p>
-      <p className="flex-1">{candidate.applied}</p>
-      <p className="flex-1">{candidate.cvFile}</p>
+    <ButtonLink to="/" className="flex flex-wrap justify-between border-b-2 border-primary py-4">
+      <p className="flex-1 text-center">{candidate.fullname}</p>
+      <p className="flex-1 text-center">{candidate.applied}</p>
+      <p className="flex-1 text-center">{candidate.cvFile}</p>
     </ButtonLink>
   );
 };

--- a/src/components/DashboardPage/PipelineCard/PipelineCard.tsx
+++ b/src/components/DashboardPage/PipelineCard/PipelineCard.tsx
@@ -33,7 +33,9 @@ const PipelineCard = () => {
           <SingleStatus key={status.id} status={status} />
         ))}
       </article>
-      <ButtonLink to={Paths.PIPELINE}>Pokaż pełny pipeline</ButtonLink>
+      <ButtonLink className="rounded-md" to={Paths.PIPELINE}>
+        Pokaż pełny pipeline
+      </ButtonLink>
     </Card>
   );
 };

--- a/src/components/DashboardPage/TasksCard/TasksCard.tsx
+++ b/src/components/DashboardPage/TasksCard/TasksCard.tsx
@@ -20,7 +20,9 @@ const TasksCard = () => {
           <SingleTask key={task.id} task={task} />
         ))}
       </Table>
-      <ButtonLink to={Paths.MY_TASKS}>Pokaż wszystkie zadania</ButtonLink>
+      <ButtonLink className="rounded-md" to={Paths.MY_TASKS}>
+        Pokaż wszystkie zadania
+      </ButtonLink>
     </Card>
   );
 };

--- a/src/components/OffersPage/OffersPage.tsx
+++ b/src/components/OffersPage/OffersPage.tsx
@@ -1,5 +1,32 @@
+import ButtonLink from "../../common/components/ButtonLink/ButtonLink";
+import Card from "../../common/components/Card/Card";
+import Table from "../../common/components/Table/Table";
+import { useGetAllOffertsQuery } from "../../services/api/offerts/offertsApi";
+
 const OffersPage = () => {
-  return <div>OffersPage</div>;
+  const { data: allOfferts } = useGetAllOffertsQuery();
+  return (
+    <Card className="w-3/4 min-w-[350px] mx-auto p-5">
+      <Table>
+        <div className="flex pb-2 pl-4 pr-8 text-text-muted border-b-2 border-primary">
+          <p className="flex-1 text-center">Nazwa oferty</p>
+          <p className="flex-1 text-center">Poziom</p>
+          <p className="flex-1 text-center"> Status oferty</p>
+          <p className="flex-1 text-center">Data utworzenia</p>
+          <p className="flex-1 text-center">Liczba kandydatów</p>
+        </div>
+        {allOfferts?.map((offert) => (
+          <ButtonLink to="/" className="border-b-2 border-primary py-4">
+            <p className="flex-1 text-center">{offert.title}</p>
+            <p className="flex-1 text-center">{offert.level}</p>
+            <p className="flex-1 text-center">{offert.status}</p>
+            <p className="flex-1 text-center">{offert.createdAt}</p>
+            <p className="flex-1 text-center">{offert.candidates.length}</p>
+          </ButtonLink>
+        ))}
+      </Table>
+    </Card>
+  );
 };
 
 export default OffersPage;

--- a/src/mocks/data/mockOffertsData.ts
+++ b/src/mocks/data/mockOffertsData.ts
@@ -27,6 +27,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-04-01",
     updatedAt: "2025-08-10",
     candidates: ["cand-1", "cand-15", "cand-30"],
+    numberOfOpenings: 1,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-2",
@@ -54,6 +57,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-07-15",
     updatedAt: "2025-08-12",
     candidates: ["cand-5", "cand-17", "cand-26"],
+    numberOfOpenings: 3,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-3",
@@ -81,6 +87,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-06-10",
     updatedAt: "2025-08-05",
     candidates: ["cand-7", "cand-19", "cand-24"],
+    numberOfOpenings: 3,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-4",
@@ -108,6 +117,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-05-01",
     updatedAt: "2025-08-01",
     candidates: ["cand-8", "cand-20", "cand-23"],
+    numberOfOpenings: 3,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-5",
@@ -135,6 +147,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-03-20",
     updatedAt: "2025-07-30",
     candidates: ["cand-6", "cand-18", "cand-25"],
+    numberOfOpenings: 1,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-6",
@@ -162,6 +177,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-04-05",
     updatedAt: "2025-08-09",
     candidates: ["cand-2", "cand-16", "cand-29"],
+    numberOfOpenings: 3,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-7",
@@ -189,6 +207,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-07-01",
     updatedAt: "2025-08-13",
     candidates: ["cand-9", "cand-11", "cand-22"],
+    numberOfOpenings: 3,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-8",
@@ -216,6 +237,9 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-05-25",
     updatedAt: "2025-08-10",
     candidates: ["cand-10", "cand-12", "cand-21"],
+    numberOfOpenings: 1,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-9",
@@ -236,17 +260,20 @@ export const jobOffers: JobOffer[] = [
     teamSize: "8-12",
     benefits: ["Udział w zyskach", "Work-life balance", "Szkolenia leadershipowe"],
     technologies: {
-      mustHave: [],
-      niceToHave: ["Jira", "Figma", "Confluence"],
+      mustHave: ["Jira", "Figma", "Confluence"],
+      niceToHave: [],
     },
     company: "TechNova",
     createdAt: "2025-02-18",
     updatedAt: "2025-08-01",
     candidates: ["cand-4", "cand-14", "cand-27"],
+    numberOfOpenings: 2,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
   {
     id: "offer-10",
-    title: "Junior Frontend Developer",
+    title: "Frontend Developer",
     description: "Poszukujemy Junior Frontend Developera z pasją do Reacta i chęcią nauki.",
     requirements: [
       "Znajomość HTML, CSS, JavaScript",
@@ -270,5 +297,8 @@ export const jobOffers: JobOffer[] = [
     createdAt: "2025-08-10",
     updatedAt: "2025-08-18",
     candidates: ["cand-3", "cand-13", "cand-28"],
+    numberOfOpenings: 2,
+    validUntil: "2025-12-31",
+    source: "careerPage",
   },
 ];

--- a/src/mocks/types/mockOffert.ts
+++ b/src/mocks/types/mockOffert.ts
@@ -23,4 +23,7 @@ export interface JobOffer {
   createdAt: string;
   updatedAt: string;
   candidates: string[];
+  numberOfOpenings: number;
+  validUntil: string;
+  source: string;
 }


### PR DESCRIPTION
## Co zostało zrobione:

- Dodano widok listy ofert pracy (job offerts) wraz z tabelą wyświetlającą dane.
- Uzupełniono mockowane dane ofert o pola:
- source (źródło oferty)
- validUntil (ważność oferty)
- numberOfOpenings (liczba dostępnych pozycji)

- Dodano wstępne style do linków/przycisków:
   - text-center
   - rounded
   - usunięto gap
   - zmodyfikowano style linków w przyciskach

Jak przetestować:

- Uruchom aplikację i zaloguj się.
- Przejdź do sekcji ofert pracy (np. /job-offerts, jeśli jest dostępna).

- Zweryfikuj, czy:
  - wyświetlana jest tabela ofert,
  - dane są zgodne z mockami,
  - pola source, validUntil, numberOfOpenings są widoczne,
  - stylizacja elementów (linki, przyciski) wygląda spójnie z resztą aplikacji.